### PR TITLE
Try working around page.url lacking path

### DIFF
--- a/es/criteria/index.md
+++ b/es/criteria/index.md
@@ -3,4 +3,4 @@
 {% assign sorted = site.pages | sort:"order" %}
 
 {% for page in sorted %}{% if page.dir == "/es/criteria/" %}{% if page.name != "index.md" %}{% if page.title %}
-1. [{{page.title}}]({{page.url}}){% endif%}    {% endif%}  {% endif%}{% endfor %}
+1. [{{page.title}}]({{site.baseurl}}{{page.url}}){% endif%}    {% endif%}  {% endif%}{% endfor %}


### PR DESCRIPTION
While the other links all work, the assembled index page loses
the repository name when rendered as a gh-pages site.

-----
[View rendered es/criteria/index.md](https://github.com/publiccodenet/community-translations-standard/blob/try-sitebaseurl-20220203/es/criteria/index.md)