### PR TITLE
Bash scripts to convert .md to and from .po for de (and more languages if configured)

### DIFF
--- a/script/PO2markdown.sh
+++ b/script/PO2markdown.sh
@@ -1,0 +1,40 @@
+#! /bin/bash
+# Author: Silvério Santos <ssantos@web.de>
+# Requires: 
+#   Package bash
+#   Package mdpo (po2md), 
+#   Folder standard on the same level as community-translations-standard
+#   File structure as created by markdown2PO.sh
+# Todo: avoid filearray and langs definition in different scripts
+
+# Languages to create PO files for and to have available for translation
+declare -a langs=('de')
+
+# Declare what single files to process from the standard base folder
+declare -a filearray=('index' 'introduction' 'readers-guide' 'glossary' 'CONTRIBUTING' 'GOVERNANCE' 'CHANGELOG' 'AUTHORS')
+
+#####
+
+function poToMdFile() {
+    for lang in ${langs[@]};  do
+        po2md -q --po-encoding UTF-8 -p ../pot/$lang/$1.po -s../$lang/$1.md ../../standard/$1.md
+    done
+}
+
+# Create folders for translated MD files, if not exist
+for lang in ${langs[@]};  do
+    if [ ! -d ../$lang/criteria ]; then
+        mkdir -p ../$lang/criteria
+    fi
+done
+
+# Translates single PO files into MD files
+for filebody in ${filearray[@]}; do
+    poToMdFile $filebody
+done
+
+# Translates PO files in subfolder criteria into MD files
+for path in $(find ../pot/criteria -type f -name '*.pot'); do
+    poToMdFile "/criteria/"`basename ${path} .pot`
+done
+

--- a/script/markdown2PO.sh
+++ b/script/markdown2PO.sh
@@ -1,0 +1,48 @@
+#! /bin/bash
+# Author: Silvério Santos <ssantos@web.de>
+# Requires: 
+#   Package mdpo (md2po), 
+#   Package gettext (msgmerge), 
+#   Folder standard on the same level as community-translations-standard
+# Todo: avoid filearray and langs definition in different scripts
+
+# Languages to create PO files for and to have available for translation
+declare -a langs=('de')
+
+# Declare what single files to process from the standard base folder
+declare -a filearray=('index' 'introduction' 'readers-guide' 'glossary' 'CONTRIBUTING' 'GOVERNANCE' 'CHANGELOG' 'AUTHORS')
+
+#####
+
+# Creates a POT file and merges it with respective language specific PO file
+# Parameters: File basename of the MD file (no extension), optionally prepended by the relative path
+function mdToPoFile() {
+    md2po -q --po-encoding UTF-8 -s -po ../pot/$1.pot ../../standard/$1.md
+    for lang in ${langs[@]};  do
+        if [ -f ../pot/$lang/$1.po ]; then
+            msgmerge -U ../pot/$lang/$1.po ../pot/$1.pot;
+        else
+            cp ../pot/$1.pot ../pot/$lang/$1.po
+        fi
+    done
+}
+
+# Translates single files from MD to POT and language specific POs
+for filebody in ${filearray[@]}; do
+    mdToPoFile $filebody
+done
+
+# subfolder: criteria
+# Create POT criteria subfolder, if not exists
+if [ ! -d ../pot/criteria ]; then
+    mkdir ../pot/criteria
+fi
+# Create translation PO subfolders, if not exist
+for lang in ${langs[@]};  do
+    if [ ! -d ../pot/$lang/criteria ]; then
+        mkdir -p ../pot/$lang/criteria
+    fi
+done
+for path in $(find ../../standard/criteria -type f -name '*.md'); do
+    mdToPoFile "criteria/"`basename ${path} .md`
+done


### PR DESCRIPTION
Gettext .po translation files make the initial translation and also subsequent text changes a lot easier by its broad compatibility with desktop and online translation tools.
Script markdown2PO.sh to convert from .md to .pot and to language specific po-files.
Script PO2markdown.sh to convert from (potentially translated) language specific .po files and the original .md files into translated .md files (if done).